### PR TITLE
Add box cardboard

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -5,9 +5,9 @@
   description: A cardboard box for storing things.
   components:
   - type: Item
-    size: Large
+    size: Normal
     shape:
-    - 0,0,2,2
+    - 0,0,1,1
   - type: Storage
     maxItemSize: Small
     grid:

--- a/Resources/Prototypes/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/jobs.yml
@@ -491,6 +491,8 @@
   parent: SpawnPointJobBase
   name: brigmedic
   components:
+  - type: SpawnPoint
+    job_id: Brigmedic
   - type: Sprite
     layers:
       - state: green

--- a/Resources/Prototypes/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/brigmedic.yml
@@ -1,0 +1,35 @@
+- type: job
+  id: Brigmedic
+  name: job-name-brigmedic
+  description: job-description-brigmedic
+  playTimeTracker: JobBrigmedic
+  requirements:
+    - !type:DepartmentTimeRequirement
+      department: Medical
+      time: 18000
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 7200
+  startingGear: BrigmedicGear
+  icon: "JobIconBrigmedic"
+  supervisors: job-supervisors-hos
+  canBeAntag: false
+  access:
+    - Medical
+    - Security
+    - Brig
+    - Maintenance
+    - External
+  #start-backmen: currency
+  minBankBalance: 150
+  maxBankBalance: 250
+  wageDepartment: Security
+  wage: 50
+  #end-backmen: currency
+  special:
+    - !type:AddComponentSpecial
+      components:
+        - type: PsionicBonusChance
+          flatBonus: 0.025
+    - !type:AddImplantSpecial
+      implants: [ MindShieldImplant ]


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. ТЕКСТ МЕЖДУ СТРЕЛКАМИ - ЭТО КОММЕНТАРИИ, ОНИ НЕ БУДУТ ВИДНЫ В ОПИСАНИИ PR. -->

## Описание PR
Уменьшен аварийный запас на 2х2 а не 3х3

## Почему / Зачем / Баланс
Сделано по заказу 

## Технические детали
Изменены параметры компонента Item в entity-прототипе картонной коробки:
Размер предмета изменен с Large на Normal
Форма предмета изменена с 2,2 на 1,1

## Медиа
Отсутствует. 

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
Изменение затрагивает размер предмета "cardboard box" в инвентаре. Теперь он занимает 1x1 клетку вместо 2x2, что делает его более удобным для переноски.

**Список изменений**
- tweak: Аварийный запас теперь не 3x3 а 2x2 
