### PR TITLE
Вульповость и стимуляторы

### DIFF
--- a/Resources/Locale/ru-RU/_Erida/traits/traits.ftl
+++ b/Resources/Locale/ru-RU/_Erida/traits/traits.ftl
@@ -12,3 +12,6 @@ trait-roar-desc = Голос, не признающий полутонов.
 
 trait-medieval-name = Средневековый акцент
 trait-medieval-desc = Удивительно, что вы не скелет со щитом.
+
+trait-vulpkanin-full-name = Пресет Вульпканина
+trait-vulpkanin-full-desc = Добавляет персонажу звуки, действия и механики, характерные для вульпканинов

--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -138,8 +138,8 @@
   - type: ToggleClothing
     action: ActionToggleSpeedBoots
   - type: ClothingSpeedModifier
-    walkModifier: 1.1 # Erida-edit 1.5 -> 1.1
-    sprintModifier: 1.1 # Erida-edit 1.5 -> 1.1
+    walkModifier: 1.25 # Erida-edit 1.5 -> 1.25
+    sprintModifier: 1.25 # Erida-edit 1.5 -> 1.25
     standing: true
   - type: Appearance
   - type: GenericVisualizer

--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -138,8 +138,8 @@
   - type: ToggleClothing
     action: ActionToggleSpeedBoots
   - type: ClothingSpeedModifier
-    walkModifier: 1.25 # Erida-edit 1.5 -> 1.25
-    sprintModifier: 1.25 # Erida-edit 1.5 -> 1.25
+    walkModifier: 1.1 # Erida-edit 1.5 -> 1.1
+    sprintModifier: 1.1 # Erida-edit 1.5 -> 1.1
     standing: true
   - type: Appearance
   - type: GenericVisualizer

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -103,8 +103,8 @@
       effects:
       # Main effects
       - !type:MovementSpeedModifier
-        walkSpeedModifier: 1.08 # Erida-edit 1.15 -> 1.08
-        sprintSpeedModifier: 1.08 # Erida-edit 1.15 -> 1.08
+        walkSpeedModifier: 1.1 # Erida-edit 1.15 -> 1.1
+        sprintSpeedModifier: 1.1 # Erida-edit 1.15 -> 1.1
       - !type:ModifyStatusEffect
         effectProto: StatusEffectStunned
         time: 1
@@ -176,8 +176,8 @@
       effects:
       # Main effects
       - !type:MovementSpeedModifier
-        walkSpeedModifier: 1.20 # Erida-edit 1.25 -> 1.20
-        sprintSpeedModifier: 1.20 # Erida-edit 1.25 -> 1.20
+        walkSpeedModifier: 1.25 
+        sprintSpeedModifier: 1.25 
       - !type:ModifyStatusEffect
         effectProto: StatusEffectStimulantsStamina # You are on meth. You keep going.
         time: 3

--- a/Resources/Prototypes/_Backmen/Research/engineering.yml
+++ b/Resources/Prototypes/_Backmen/Research/engineering.yml
@@ -49,7 +49,7 @@
     state: microreactor
   discipline: Engineering
   tier: 1
-  cost: 20000
+  cost: 25000
   recipeUnlocks:
    - PowerCellMicroreactor
   technologyPrerequisites:

--- a/Resources/Prototypes/_Backmen/Research/scientific.yml
+++ b/Resources/Prototypes/_Backmen/Research/scientific.yml
@@ -155,7 +155,7 @@
     state: icon
   discipline: Scientific
   tier: 1
-  cost: 12500
+  cost: 30000
   recipeUnlocks:
   - ClothingShoesBootsSpeed
   technologyPrerequisites:

--- a/Resources/Prototypes/_Erida/Reagents/gases.yml
+++ b/Resources/Prototypes/_Erida/Reagents/gases.yml
@@ -146,8 +146,8 @@
       effects:
       - !type:MovementSpeedModifier
         conditions:
-        walkSpeedModifier: 1.15 # 1.35 -> 1.15
-        sprintSpeedModifier: 1.15 # 1.35 -> 1.15
+        walkSpeedModifier: 1.35
+        sprintSpeedModifier: 1.35 
         time: 0.07
       - !type:HealthChange
         conditions:

--- a/Resources/Prototypes/_Erida/Traits/species.yml
+++ b/Resources/Prototypes/_Erida/Traits/species.yml
@@ -1,0 +1,56 @@
+- type: trait
+  id: VulpkaninFull
+  name: trait-vulpkanin-full-name
+  description: trait-vulpkanin-full-desc
+  category: Species
+  conditions:
+  - !type:IsSpeciesCondition
+    species: Anthropomorph
+  effects:
+  - !type:AddCompsEffect
+    removeExisting: true
+    components:
+    - type: Vocal
+      sounds:
+        Male: MaleVulpkanin
+        Female: FemaleVulpkanin
+        Unsexed: MaleVulpkanin
+    - type: Speech
+      speechVerb: Vulpkanin
+      allowedEmotes: [ 'Bark', 'Snarl', 'Whine', 'Howl', 'Growl' ]
+      speechSounds: Vulpkanin
+    - type: LanguageKnowledge
+      speaks:
+      - TauCetiBasic
+      - Canilunzt
+      understands:
+      - TauCetiBasic
+      - Canilunzt
+    - type: LanguageSpeaker
+      currentLanguage: TauCetiBasic
+    - type: Temperature
+      specificHeat: 44
+    - type: TemperatureDamage
+      heatDamageThreshold: 320
+      coldDamageThreshold: 230
+      coldDamage:
+        types:
+          Cold: 0.05
+      heatDamage:
+        types:
+          Heat: 2.5
+    - type: TemperatureProtection
+      heatingCoefficient: 1.2
+      coolingCoefficient: 0.3
+    - type: JumpAbility
+      action: ActionVulpkaninGravityJump
+      canCollide: true
+      jumpDistance: 3
+      jumpSound:
+        path: /Audio/Weapons/punchmiss.ogg
+        params:
+          pitch: 1.33
+          volume: -5
+          variation: 0.05
+    - type: MessyDrinker
+      spillChance: 0.33


### PR DESCRIPTION
Наконец-то, Вульповость

<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. ТЕКСТ МЕЖДУ СТРЕЛКАМИ - ЭТО КОММЕНТАРИИ, ОНИ НЕ БУДУТ ВИДНЫ В ОПИСАНИИ PR. -->

## Описание PR
Добавил черту вульповости и сделал более балансное ускорение от стимуляторов и скороходов 
~~Скороходы - 1.1 -> 1.25~~
Нитриум 1.15 -> 1.35
Эфедрин 1.08 -> 1.1
Гиперзин 1.2 -> 1.25
Стоимость изучения микрореакторной батареи 20000 -> 25000
Скороходы 12500 -> 30000

## Почему / Зачем / Баланс
<!-- Обсудите, как это повлияет на баланс игры или объясните, почему это было изменено. Укажите ссылки на соответствующие обсуждения, предложение или issue. -->
Баланс, с прошлым ускорением ни в стимуляторах, ни в скороходах не было абсолютно никакого смысла, ибо скорость повышалась настолько незначительно, что делать какие либо усилия для их создания смысла нет. 

И пресет вульповости _воет воет воет_.

## Технические детали
<!-- Краткое описание изменений в коде для облегчения проверки. -->

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->
