### PR TITLE
Kk

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -268,15 +268,17 @@
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
-  - type: Armor
+  - type: Armor #Erida edit
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.7
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.65
+        Heat: 0.7
+        Caustic: 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.65
-    sprintModifier: 0.65
+    walkModifier: 0.85
+    sprintModifier: 0.85
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitBrigmedic
@@ -613,20 +615,20 @@
     reduction: 0.8
   - type: StaminaResistance # do not add these to other equipment or mobs, we don't want to microbalance these everywhere
     damageCoefficient: 0.6
-  - type: Armor
+  - type: Armor #Erida edit
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.6
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.5
         Heat: 0.2
         Radiation: 0.01
         Caustic: 0.5
   - type: Item
     size: Huge
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 0.95
+    sprintModifier: 0.95
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieElite

--- a/Resources/Prototypes/_Backmen/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/_Backmen/Entities/Clothing/Head/helmets.yml
@@ -32,3 +32,10 @@
     tags:
     - WhitelistChameleon
     - SecurityHelmet
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.8
+        Slash: 0.9
+        Piercing: 0.9
+        Heat: 0.9

--- a/Resources/Prototypes/_Corvax/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_Corvax/Entities/Clothing/OuterClothing/coats.yml
@@ -71,12 +71,12 @@
     - type: Armor # Based on /tg/ but slightly compensated to fit the fact that armor stacks in SS14. :x:
       modifiers:
         coefficients: # Erida
-          Blunt: 0.60
-          Slash: 0.60
-          Piercing: 0.50 #Can save you, but bullets will still hurt. Will take about 10 shots from a Viper before critting, as opposed to 7 while unarmored and 16~ with a bulletproof vest.
-          Heat: 0.70
-    - type: StaminaResistance
-      damageCoefficient: 0.65
+          Blunt: 0.7
+          Slash: 0.7
+          Piercing: 0.7 #Can save you, but bullets will still hurt. Will take about 10 shots from a Viper before critting, as opposed to 7 while unarmored and 16~ with a bulletproof vest.
+          Heat: 0.8
+    - type: ExplosionResistance
+        damageCoefficient: 0.90
 
 - type: entity
   parent: ClothingOuterStorageBase

--- a/Resources/Prototypes/_Corvax/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_Corvax/Entities/Clothing/OuterClothing/coats.yml
@@ -76,7 +76,7 @@
           Piercing: 0.7 #Can save you, but bullets will still hurt. Will take about 10 shots from a Viper before critting, as opposed to 7 while unarmored and 16~ with a bulletproof vest.
           Heat: 0.8
     - type: ExplosionResistance
-        damageCoefficient: 0.90
+      damageCoefficient: 0.90
 
 - type: entity
   parent: ClothingOuterStorageBase

--- a/Resources/Prototypes/_Corvax/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/_Corvax/Entities/Clothing/OuterClothing/vests.yml
@@ -33,7 +33,7 @@
     - type: Armor
       modifiers:
         coefficients: # Erida
-          Blunt: 0.6
-          Slash: 0.6
-          Piercing: 0.6
-          Heat: 0.7
+          Blunt: 0.7
+          Slash: 0.7
+          Piercing: 0.7
+          Heat: 0.8

--- a/Resources/Prototypes/_Orion/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Orion/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -64,5 +64,5 @@
         Radiation: 0.4
         Caustic: 0.4
   - type: ClothingSpeedModifier
-    walkModifier: 1
-    sprintModifier: 1
+    walkModifier: 0.9
+    sprintModifier: 0.9

--- a/Resources/Prototypes/_Orion/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Orion/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -13,12 +13,12 @@
   - type: Armor
     modifiers:
       coefficients: # Erida
-        Blunt: 0.45
-        Slash: 0.45
-        Piercing: 0.40
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.5
         Heat: 0.2
         Radiation: 0.01
-        Caustic: 0.4
+        Caustic: 0.5
 
 - type: entity
   parent: [ BaseMajorContraband, ClothingOuterHardsuitSyndie ]
@@ -35,12 +35,12 @@
   - type: Armor
     modifiers:
       coefficients: # Erida
-        Blunt: 0.40
-        Slash: 0.40
-        Piercing: 0.40
-        Heat: 0.40
-        Radiation: 0.4
-        Caustic: 0.4
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.5
+        Heat: 0.5
+        Radiation: 0.5
+        Caustic: 0.5
 
 - type: entity
   parent: [ BaseMajorContraband, ClothingOuterHardsuitSyndie ]

--- a/Resources/Prototypes/_Orion/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Orion/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -10,15 +10,6 @@
     sprite: _Orion/Clothing/OuterClothing/Hardsuits/elite_inteq_hardsuit.rsi
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitInteQElite
-  - type: Armor
-    modifiers:
-      coefficients: # Erida
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5
-        Heat: 0.2
-        Radiation: 0.01
-        Caustic: 0.5
 
 - type: entity
   parent: [ BaseMajorContraband, ClothingOuterHardsuitSyndie ]
@@ -32,15 +23,6 @@
     sprite: _Orion/Clothing/OuterClothing/Hardsuits/inteq_hardsuit.rsi
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitInteQ
-  - type: Armor
-    modifiers:
-      coefficients: # Erida
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5
-        Heat: 0.5
-        Radiation: 0.5
-        Caustic: 0.5
 
 - type: entity
   parent: [ BaseMajorContraband, ClothingOuterHardsuitSyndie ]
@@ -54,15 +36,3 @@
     sprite: _Orion/Clothing/OuterClothing/Hardsuits/inteq_syn_hardsuit.rsi
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndicateInteQ
-  - type: Armor
-    modifiers:
-      coefficients: # Erida
-        Blunt: 0.50
-        Slash: 0.50
-        Piercing: 0.50
-        Heat: 0.50
-        Radiation: 0.4
-        Caustic: 0.4
-  - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9


### PR DESCRIPTION
## Описание PR
Подправил резисты у скафандра и куртки бригмедика, шинели ГСБ, шлема пилота СБ, прировнял скафандры InteQ к синдикат версиям. 
Элитные версии скафандров теперь имеют право на существования, основные резисты равны стандартному кроваво-красному скафандру, замедление снижено на 5%

## Дла чего / Баланс
Баланс и забытое

## Медиа
<!-- Прилагайте медиафайлы, если PR вносит изменения в игровой процесс (одежда, предметы, функции и т. д.).
Незначительные исправления и рефакторинг - исключение.-->

## Требования
<!-- Подтвердите следующее, поставив галочку [X] в скобках: -->
- [X] Я протестировал свои изменения локально и убедился, что они работают как положено.
- [X] Я добавил медиафайлы в этот PR, либо он не требует демонстрации в игре.
- [X] Я могу подтвердить, что этот PR не содержит контента, сгенерированного ИИ.
<!-- Вы должны понимать, что несоблюдение вышеуказанных требований может привести к закрытию вашего PR по усмотрению сопровождающего -->
<!-- При использовании ИИ убедитесь, что вы уже владеете навыками создания того контента, который собираетесь генерировать, и что у вас уже есть опыт участия в разработке SS14. ИИ Должен использоваться МАКСИМУМ для оптимизации вашего существующего рабочего процесса, а не для «вайбкодинга». -->

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Changelog**
:cl: Tiwulovoe
- tweak: Скафандры InteQ равны синдикату
- tweak: SyndieElite 40 40 40 -> 50 50 50, замедление 10 -> 5
- fix: Исправлены резисты скафандра и куртки бригмедика, шлем пилота CБ, шинель ГСБ
