### PR TITLE
Next ammo description

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -9,6 +9,7 @@ using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Weapons.Ranged.Systems;
@@ -184,6 +185,29 @@ public abstract partial class SharedGunSystem
             return;
 
         args.PushMarkup(Loc.GetString("gun-magazine-examine", ("color", AmmoExamineColor), ("count", GetBallisticShots(ent.Comp))));
+
+        if (TryGetNextAmmoName(ent, out var ammoName))
+            args.PushMarkup(Loc.GetString("gun-magazine-next-ammo", ("color", AmmoExamineColor), ("ammo", ammoName)));
+    }
+
+    private bool TryGetNextAmmoName(Entity<BallisticAmmoProviderComponent> entity, out string ammoName)
+    {
+        ammoName = string.Empty;
+
+        if (entity.Comp.Container.Count + entity.Comp.UnspawnedCount == 0)
+            return false;
+
+        if (entity.Comp.Container.Count == 0)
+        {
+            if (entity.Comp.Proto == null)
+                return false;
+
+            ammoName = ProtoManager.Index<EntityPrototype>(entity.Comp.Proto).Name;
+        }
+        else
+            ammoName = Name(entity.Comp.Entities[^1]);
+
+        return true;
     }
 
     private void ManualCycle(Entity<BallisticAmmoProviderComponent> ent, MapCoordinates coordinates, EntityUid? user = null, GunComponent? gunComp = null)

--- a/Resources/Locale/en-US/weapons/ranged/gun.ftl
+++ b/Resources/Locale/en-US/weapons/ranged/gun.ftl
@@ -42,6 +42,7 @@ gun-chamber-rack = Rack
 
 # MagazineAmmoProvider
 gun-magazine-examine = It has [color={$color}]{$count}[/color] shots remaining.
+gun-magazine-next-ammo = Next cartridge: [color={$color}]{$ammo}[/color]
 
 # RevolverAmmoProvider
 gun-revolver-empty = Empty revolver

--- a/Resources/Locale/ru-RU/weapons/ranged/gun.ftl
+++ b/Resources/Locale/ru-RU/weapons/ranged/gun.ftl
@@ -45,6 +45,7 @@ gun-magazine-examine =
         [few] штуки
        *[other] штук
     }.
+gun-magazine-next-ammo = Следующий патрон: [color={$color}]{$ammo}[/color]
 # RevolverAmmoProvider
 gun-revolver-empty = Разрядить револьвер
 gun-revolver-full = Револьвер полностью заряжен


### PR DESCRIPTION
## Описание PR
Добавление в описание магазинов информации о след. патроне

## Дла чего / Баланс
Удобство

## Медиа
<img width="430" height="400" alt="image" src="https://github.com/user-attachments/assets/3cbf3fd3-61fc-4d40-bd53-f03a97dc8188" />

## Требования

- [X] Я протестировал свои изменения локально и убедился, что они работают как положено.
- [X] Я добавил медиафайлы в этот PR, либо он не требует демонстрации в игре.
- [X] Я могу подтвердить, что этот PR не содержит контента, сгенерированного ИИ.

**Changelog**
<!-- Добавьте запись в Changelog, чтобы игроки были в курсе новых функций или изменений, которые могут повлиять на игровой процесс.
Обязательно ознакомьтесь с рекомендациями и удалите этот шаблон чейнджлога из блока комментариев, чтобы он отобразился.
Чейнджлог должен содержать символ :cl:, чтобы бот распознал изменения и добавил их. -->

:cl: Sidzaru
- add: Магазины патронов отображают в описании информацию о следующем патроне 
