### PR TITLE
[Add] Base of automatic votes

### DIFF
--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -118,6 +118,7 @@ namespace Content.Client.Entry
             _prototypeManager.RegisterIgnore("gameMap");
             _prototypeManager.RegisterIgnore("gameMapPool");
             _prototypeManager.RegisterIgnore("gamePreset");
+            _prototypeManager.RegisterIgnore("autoVotes"); // Erida edit
             _prototypeManager.RegisterIgnore("noiseChannel");
             _prototypeManager.RegisterIgnore("playerConnectionWhitelist");
             _prototypeManager.RegisterIgnore("spaceBiome");

--- a/Content.Server/GameTicking/GameTicker.GamePreset.cs
+++ b/Content.Server/GameTicking/GameTicker.GamePreset.cs
@@ -14,7 +14,7 @@ namespace Content.Server.GameTicking;
 
 public sealed partial class GameTicker
 {
-    public const float PresetFailedCooldownIncrease = 30f;
+    public const float PresetFailedCooldownIncrease = -45f; // Erida edit
 
     /// <summary>
     /// The selected preset that will be used at the start of the next round.

--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -142,7 +142,7 @@ namespace Content.Server.Voting.Managers
         {
             // Handle active votes.
             var remQueue = new RemQueue<int>();
-            foreach (var v in _votes.Values)
+            foreach (var v in _votes.Values.ToArray()) // Erida edit
             {
                 // Logger.Debug($"{_timing.ServerTime}");
                 if (_timing.RealTime >= v.EndTime)
@@ -276,7 +276,7 @@ namespace Content.Server.Voting.Managers
                 msg.IsYourVoteDirty = dirty;
                 if (dirty)
                 {
-                    msg.YourVote = (byte) cast;
+                    msg.YourVote = (byte)cast;
                 }
             }
 
@@ -290,7 +290,7 @@ namespace Content.Server.Voting.Managers
             for (var i = 0; i < msg.Options.Length; i++)
             {
                 ref var entry = ref v.Entries[i];
-                msg.Options[i] = (msg.DisplayVotes ? (ushort) entry.Votes : (ushort) 0, entry.Text);
+                msg.Options[i] = (msg.DisplayVotes ? (ushort)entry.Votes : (ushort)0, entry.Text);
             }
 
             player.Channel.SendMessage(msg);
@@ -401,7 +401,7 @@ namespace Content.Server.Voting.Managers
                 .ToImmutableArray();
             // Store all votes in order for webhooks
             var voteTally = new List<int>();
-            foreach(var entry in v.Entries)
+            foreach (var entry in v.Entries)
             {
                 voteTally.Add(entry.Votes);
             }

--- a/Content.Server/_Erida/Lobby/AutoVotesPrototype.cs
+++ b/Content.Server/_Erida/Lobby/AutoVotesPrototype.cs
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Lytheriia
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Server.GameTicking.Presets;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Erida.Lobby;
+
+[Prototype]
+public sealed partial class AutoVotesPrototype : IPrototype
+{
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    [DataField(required: true)]
+    public LocId Title;
+
+    [DataField(required: true)]
+    public List<AutoVoteOptionData> Options = [];
+
+    [DataField]
+    public bool ShouldBeInFirstVote = false;
+}
+
+[DataDefinition]
+public partial struct AutoVoteOptionData
+{
+    [DataField(required: true)]
+    public AutoVoteOptionAnswerData AnswerData;
+
+    [DataField(required: true)]
+    public LocId Label;
+}
+
+[DataDefinition]
+public partial struct AutoVoteOptionAnswerData
+{
+    [DataField(required: true)]
+    public AutoVoteOptionAction Action;
+
+    [DataField]
+    public List<ProtoId<AutoVotesPrototype>> NextVoteProto = [];
+
+    [DataField]
+    public ProtoId<GamePresetPrototype> GamePresetProto;
+}
+
+public enum AutoVoteOptionAction
+{
+    NextVote,
+    GameModeStart
+}

--- a/Content.Server/_Erida/Lobby/AutoVotesSystem.cs
+++ b/Content.Server/_Erida/Lobby/AutoVotesSystem.cs
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: 2026 Lytheriia
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Server.Administration.Logs;
+using Content.Server.Chat.Managers;
+using Content.Server.GameTicking;
+using Content.Server.GameTicking.Events;
+using Content.Server.Voting;
+using Content.Server.Voting.Managers;
+using Content.Shared.CCVar;
+using Content.Shared.Database;
+using Content.Shared.GameTicking;
+using Robust.Server.Player;
+using Robust.Shared.Configuration;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Server._Erida.Lobby;
+
+public sealed partial class AutoVotesSystem : EntitySystem
+{
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private IVoteManager _voteManager = default!;
+    [Dependency] private GameTicker _gameTicker = default!;
+    [Dependency] private IConfigurationManager _cfg = default!;
+    [Dependency] private IPrototypeManager _prototypeManager = default!;
+    [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private IChatManager _chatManager = default!;
+    [Dependency] private IAdminLogManager _adminLog = default!;
+    [Dependency] private IEntityManager _entityManager = default!;
+    [Dependency] private IPlayerManager _playerManager = default!;
+
+    private List<string> _previousGamerules = [];
+    private AutoVoteOptionData _previousChoosedMainOption = new();
+    private TimeSpan _startAfter = TimeSpan.Zero;
+    private bool _voteTriggered;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _cfg.OnValueChanged(CCVars.AutomaticVoteStartAt,
+            value =>
+            {
+                if (value != TimeSpan.Zero)
+                    _startAfter = value;
+            }, true);
+
+        SubscribeLocalEvent<RoundStartingEvent>(OnRoundStarting);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestartCleanup);
+    }
+
+    private void FindAndStartMainVotes()
+    {
+        var options = new VoteOptions
+        {
+            Duration = _cfg.GetCVar(CCVars.AutomaticVoteDuration),
+        };
+
+        options.InitiatorText = Loc.GetString("ui-vote-initiator-server");
+
+        if (_cfg.GetCVar(CCVars.AutomaticVoteMinPlayersForForce) < _playerManager.PlayerCount)
+        {
+            foreach (var proto in _prototypeManager.EnumeratePrototypes<AutoVotesPrototype>())
+                if (proto.ShouldBeInFirstVote)
+                {
+                    options.Title = Loc.GetString(proto.Title);
+
+                    foreach (var x in proto.Options)
+                    {
+                        if (_previousChoosedMainOption.Label == x.Label)
+                            continue;
+
+                        options.Options.Add((Loc.GetString(x.Label), x));
+                        break;
+                    }
+                    break;
+                }
+
+        }
+        else
+            foreach (var proto in _prototypeManager.EnumeratePrototypes<AutoVotesPrototype>())
+                if (proto.ShouldBeInFirstVote)
+                {
+                    options.Title = Loc.GetString(proto.Title);
+
+                    foreach (var option in proto.Options)
+                    {
+                        options.Options.Add((Loc.GetString(option.Label), option));
+                    }
+
+                    break;
+                }
+
+        var vote = _voteManager.CreateVote(options);
+
+        vote.OnFinished += (_, args) => OnFinished(args);
+    }
+
+    private void OnFinished(VoteFinishedEventArgs args)
+    {
+        AutoVoteOptionData winner;
+        if (args.Winner == null)
+        {
+            winner = (AutoVoteOptionData)_random.Pick(args.Winners);
+            _chatManager.DispatchServerAnnouncement(
+                Loc.GetString("ui-vote-gamemode-tie", ("picked", Loc.GetString(winner.Label))));
+        }
+        else
+        {
+            winner = (AutoVoteOptionData)args.Winner;
+            _chatManager.DispatchServerAnnouncement(
+                Loc.GetString("ui-vote-gamemode-win", ("winner", Loc.GetString(winner.Label))));
+        }
+
+        _previousChoosedMainOption = winner;
+
+        _adminLog.Add(LogType.Vote, LogImpact.Medium, $"Preset vote finished: {winner.Label}");
+
+        switch (winner.AnswerData.Action)
+        {
+            case AutoVoteOptionAction.NextVote:
+                {
+                    StartNewVote(winner.AnswerData);
+                    break;
+                }
+            case AutoVoteOptionAction.GameModeStart:
+                {
+                    StartGamePreset(winner.AnswerData);
+                    break;
+                }
+            default:
+                {
+                    break;
+                }
+        }
+    }
+
+    private void StartNewVote(AutoVoteOptionAnswerData data)
+    {
+        var options = new VoteOptions
+        {
+            Duration = _cfg.GetCVar(CCVars.AutomaticVoteDuration),
+        };
+
+        foreach (var proto in data.NextVoteProto)
+        {
+            var protoData = _prototypeManager.Index(proto);
+            options.Title = Loc.GetString(protoData.Title);
+            options.InitiatorText = Loc.GetString("ui-vote-initiator-server");
+
+            foreach (var option in protoData.Options)
+            {
+                if (option.AnswerData.Action == AutoVoteOptionAction.GameModeStart
+                    && _previousGamerules.Count != 0
+                    && option.AnswerData.GamePresetProto.Id == _previousGamerules[_previousGamerules.Count - 1])
+                    continue;
+
+                options.Options.Add((Loc.GetString(option.Label), option));
+            }
+        }
+
+        var vote = _voteManager.CreateVote(options);
+
+        // Hello to recursion <3
+        vote.OnFinished += (_, args) => OnFinished(args);
+    }
+
+    private void StartGamePreset(AutoVoteOptionAnswerData data)
+    {
+        if (_previousGamerules.Count >= 3)
+            _previousGamerules.RemoveAt(0);
+
+        _previousGamerules.Add(data.GamePresetProto.Id);
+
+        var ticker = _entityManager.EntitySysManager.GetEntitySystem<GameTicker>();
+        ticker.SetGamePreset(data.GamePresetProto);
+    }
+
+    private void OnRoundStarting(RoundStartingEvent _)
+    {
+        _voteTriggered = false;
+    }
+
+    private void OnRoundRestartCleanup(RoundRestartCleanupEvent _)
+    {
+        _voteTriggered = false;
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_gameTicker.RunLevel != GameRunLevel.PreRoundLobby)
+            return;
+
+        if (_voteTriggered)
+            return;
+
+        var remaining = _gameTicker.RoundStartTimeSpan - _timing.CurTime;
+
+        if (-remaining >= _startAfter)
+        {
+            _voteTriggered = true;
+
+            _voteManager.CreateStandardVote(null, Shared.Voting.StandardVoteType.Map);
+
+            FindAndStartMainVotes();
+        }
+    }
+}

--- a/Content.Server/_Erida/Lobby/AutoVotesSystem.cs
+++ b/Content.Server/_Erida/Lobby/AutoVotesSystem.cs
@@ -196,6 +196,9 @@ public sealed partial class AutoVotesSystem : EntitySystem
         if (_gameTicker.RunLevel != GameRunLevel.PreRoundLobby)
             return;
 
+        if (_playerManager.PlayerCount == 0)
+            return;
+
         if (_voteTriggered)
             return;
 

--- a/Content.Server/_Erida/Lobby/AutoVotesSystem.cs
+++ b/Content.Server/_Erida/Lobby/AutoVotesSystem.cs
@@ -196,9 +196,6 @@ public sealed partial class AutoVotesSystem : EntitySystem
         if (_gameTicker.RunLevel != GameRunLevel.PreRoundLobby)
             return;
 
-        if (_playerManager.PlayerCount == 0)
-            return;
-
         if (_voteTriggered)
             return;
 

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -39,7 +39,7 @@ public sealed partial class CCVars
     ///     Controls if the game can force a different preset if the current preset's criteria are not met.
     /// </summary>
     public static readonly CVarDef<bool>
-        GameLobbyFallbackEnabled = CVarDef.Create("game.fallbackenabled", true, CVar.ARCHIVE);
+        GameLobbyFallbackEnabled = CVarDef.Create("game.fallbackenabled", false, CVar.ARCHIVE);
 
     /// <summary>
     ///     The preset for the game to fall back to if the selected preset could not be used, and fallback is enabled.

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -39,7 +39,7 @@ public sealed partial class CCVars
     ///     Controls if the game can force a different preset if the current preset's criteria are not met.
     /// </summary>
     public static readonly CVarDef<bool>
-        GameLobbyFallbackEnabled = CVarDef.Create("game.fallbackenabled", false, CVar.ARCHIVE);
+        GameLobbyFallbackEnabled = CVarDef.Create("game.fallbackenabled", true, CVar.ARCHIVE);
 
     /// <summary>
     ///     The preset for the game to fall back to if the selected preset could not be used, and fallback is enabled.

--- a/Content.Shared/CCVar/CCVars.Vote.cs
+++ b/Content.Shared/CCVar/CCVars.Vote.cs
@@ -32,7 +32,7 @@ public sealed partial class CCVars
     ///     See vote.enabled, but specific to preset votes
     /// </summary>
     public static readonly CVarDef<bool> VotePresetEnabled =
-        CVarDef.Create("vote.preset_enabled", true, CVar.SERVERONLY);
+        CVarDef.Create("vote.preset_enabled", false, CVar.SERVERONLY);
 
     /// <summary>
     ///     See vote.enabled, but specific to map votes
@@ -72,7 +72,7 @@ public sealed partial class CCVars
     ///     Sets the duration of the map vote timer.
     /// </summary>
     public static readonly CVarDef<int>
-        VoteTimerMap = CVarDef.Create("vote.timermap", 90, CVar.SERVERONLY);
+        VoteTimerMap = CVarDef.Create("vote.timermap", 60, CVar.SERVERONLY);
 
     /// <summary>
     ///     Sets the duration of the restart vote timer.

--- a/Content.Shared/_Erida/CCVar/CCVars.Votes.cs
+++ b/Content.Shared/_Erida/CCVar/CCVars.Votes.cs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Lytheriia
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    public static readonly CVarDef<bool> AutomaticVoteEnabled =
+        CVarDef.Create("autovote.enabled", true, CVar.SERVERONLY);
+
+    public static readonly CVarDef<TimeSpan> AutomaticVoteDuration =
+        CVarDef.Create("autovote.duration", TimeSpan.FromSeconds(30), CVar.SERVERONLY);
+
+    public static readonly CVarDef<TimeSpan> AutomaticVoteStartAt =
+        CVarDef.Create("autovote.startat", TimeSpan.FromSeconds(55), CVar.SERVERONLY);
+
+    public static readonly CVarDef<int> AutomaticVoteMinPlayersForForce =
+            CVarDef.Create("autovote.minplayerceforce", 15, CVar.SERVERONLY);
+
+    public static readonly CVarDef<TimeSpan> AutomaticVoteFailedTimeReduce =
+            CVarDef.Create("autovote.failedreduce", TimeSpan.FromSeconds(-60), CVar.SERVERONLY);
+}

--- a/Resources/Locale/ru-RU/_Erida/votes/autovotes.ftl
+++ b/Resources/Locale/ru-RU/_Erida/votes/autovotes.ftl
@@ -1,0 +1,4 @@
+autovote-gamerules-title = Следующий режим игры
+
+autovote-main-gamerules-dynamic = Динамический
+autovote-main-gamerules-greenshift = Спокойный

--- a/Resources/Prototypes/_Erida/GameRules/votes.yml
+++ b/Resources/Prototypes/_Erida/GameRules/votes.yml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2026 Lytheriia
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+### Next votes
+
+- type: autoVotes
+  id: mainGR
+  title: autovote-gamerules-title
+  shouldBeInFirstVote: true
+  options:
+    - label: autovote-main-gamerules-dynamic
+      answerData:
+        action: NextVote
+        nextVoteProto:
+          - GameRuleDynamic
+
+    - label: autovote-main-gamerules-greenshift
+      answerData:
+        action: NextVote
+        nextVoteProto:
+          - GameRuleGreenshift
+
+
+### Game mode votes
+
+- type: autoVotes
+  id: GameRuleDynamic
+  title: autovote-gamerules-title
+  options:
+    - label: nukeops-title
+      answerData:
+        action: GameModeStart
+        gamePresetProto: NukeOps
+
+    - label: rev-title
+      answerData:
+        action: GameModeStart
+        gamePresetProto: Revolutionary
+
+    - label: secret-title
+      answerData:
+        action: GameModeStart
+        gamePresetProto: Secret
+
+    - label: survival-title
+      answerData:
+        action: GameModeStart
+        gamePresetProto: Survival
+
+    - label: traitor-title
+      answerData:
+        action: GameModeStart
+        gamePresetProto: Traitor
+
+    - label: zombie-title
+      answerData:
+        action: GameModeStart
+        gamePresetProto: Zombie
+
+- type: autoVotes
+  id: GameRuleGreenshift
+  title: autovote-gamerules-title
+  options:
+    - label: extended-title
+      answerData:
+        action: GameModeStart
+        gamePresetProto: Extended

--- a/Resources/Prototypes/_Erida/GameRules/votes.yml
+++ b/Resources/Prototypes/_Erida/GameRules/votes.yml
@@ -31,7 +31,7 @@
     - label: nukeops-title
       answerData:
         action: GameModeStart
-        gamePresetProto: NukeOps
+        gamePresetProto: Nukeops
 
     - label: rev-title
       answerData:


### PR DESCRIPTION
## Описание PR
1. Добавлены автоматические голосования за режим и карту
2. Изменён набор голосования за режим
3. Время старта раунда при неудачном старте сокращено на 45с
4. Добавлено чередование режимов при онлайне выше 15

## Требования
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [ ] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [ ] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
В журнал изменений следует помещать только то, что действительно важно игрокам. Если вы добавили музыку для ивента - это не важно.
Если вы понёрфили пули христова - это важно. Убедитесь, что вы вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl: Lytheriia
- Добавлено: Автоматические голосования за режим и карту
- Добавлено: Добавлено чередование режимов при онлайне выше 15
- Изменено: Голосование за режим поделено на 2 типа